### PR TITLE
Harden browser game world unlock lifecycle

### DIFF
--- a/modules/browser-game-accounts/src/Support/AccountsManager.php
+++ b/modules/browser-game-accounts/src/Support/AccountsManager.php
@@ -153,16 +153,19 @@ final class AccountsManager
 
     public function consumeRecovery(string $token): ?AccountsRecord
     {
-        $recovery = AccountRecovery::query()->where('token_hash', hash('sha512', $token))
-            ->whereNull('used_at')->where('expires_at', '>', now())
-            ->where('attempts', '<', (int) config('browser-game.accounts.maximum_recovery_attempts', 5))->first();
-        if ($recovery === null) {
-            return null;
-        }
-        $recovery->increment('attempts');
-        $recovery->update(['used_at' => now()]);
+        return DB::transaction(function () use ($token): ?AccountsRecord {
+            $recovery = AccountRecovery::query()->where('token_hash', hash('sha512', $token))
+                ->whereNull('used_at')->where('expires_at', '>', now())
+                ->where('attempts', '<', (int) config('browser-game.accounts.maximum_recovery_attempts', 5))
+                ->lockForUpdate()->first();
+            if ($recovery === null) {
+                return null;
+            }
 
-        return $recovery->account;
+            $recovery->update(['attempts' => $recovery->attempts + 1, 'used_at' => now()]);
+
+            return $recovery->account;
+        });
     }
 
     public function resolveSession(string $token): ?AccountSession

--- a/modules/browser-game-quests-api/src/Http/Controllers/QuestsController.php
+++ b/modules/browser-game-quests-api/src/Http/Controllers/QuestsController.php
@@ -41,7 +41,7 @@ final class QuestsController extends Controller
     public function accept(Request $request, Quest $quest): JsonResponse
     {
         $quest = $this->authorizedQuest($request, $quest);
-        $data = $request->validate(['completed_quests' => ['array'], 'idempotency_key' => ['nullable', 'string', 'max:128']]);
+        $data = $request->validate(['idempotency_key' => ['nullable', 'string', 'max:128']]);
 
         return response()->json(['data' => $this->progressResource(app(QuestsManager::class)->accept($quest, (string) $request->user()->getKey(), $data, $data['idempotency_key'] ?? $request->header('Idempotency-Key')))], 201);
     }

--- a/modules/browser-game-quests/src/Support/QuestsManager.php
+++ b/modules/browser-game-quests/src/Support/QuestsManager.php
@@ -34,7 +34,7 @@ final class QuestsManager
         if ($quest->status !== 'active') {
             throw ValidationException::withMessages(['quest' => 'The quest is not available.']);
         }
-        $completed = array_map('strval', (array) ($context['completed_quests'] ?? []));
+        $completed = $this->completedQuestKeys($quest, $actorId);
         $existingProgress = QuestProgress::query()->where(['quest_id' => $quest->getKey(), 'actor_id' => $actorId])->first();
         foreach ((array) ($quest->prerequisites ?? []) as $prerequisite) {
             if (! in_array((string) (is_array($prerequisite) ? ($prerequisite['quest'] ?? '') : $prerequisite), $completed, true) && ! ($quest->repeatable && (int) ($existingProgress?->completion_count ?? 0) > 0)) {
@@ -94,6 +94,9 @@ final class QuestsManager
         $completionCount = 0;
         $result = DB::transaction(function () use ($quest, $actorId, $idempotencyKey, $progress, &$rewards, &$completionCount): QuestProgress {
             $record = QuestProgress::query()->where(['quest_id' => $quest->getKey(), 'actor_id' => $actorId])->lockForUpdate()->firstOrFail();
+            if ($idempotencyKey !== null && $record->status === 'completed' && $record->last_operation_key === $idempotencyKey) {
+                return $record;
+            }
             if ($record->status === 'completed' && ! $quest->repeatable) {
                 return $record;
             }
@@ -144,6 +147,23 @@ final class QuestsManager
         }
 
         return true;
+    }
+
+    /** @return list<string> */
+    private function completedQuestKeys(Quest $quest, string $actorId): array
+    {
+        $completedIds = QuestProgress::query()
+            ->where('actor_id', $actorId)
+            ->where('status', 'completed')
+            ->select('quest_id');
+
+        $completed = Quest::query()
+            ->whereIn('id', $completedIds)
+            ->where(fn ($query) => $query->whereNull('tenant_id')->orWhere('tenant_id', $quest->tenant_id))
+            ->where(fn ($query) => $query->whereNull('team_id')->orWhere('team_id', $quest->team_id))
+            ->get(['id', 'slug']);
+
+        return $completed->flatMap(fn (Quest $completedQuest): array => [(string) $completedQuest->getKey(), (string) $completedQuest->slug])->values()->all();
     }
 
     private function assertActor(string $actorId): void

--- a/modules/browser-game-world-api/CHANGELOG.md
+++ b/modules/browser-game-world-api/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## 1.0.0 - Unreleased
 
 - Add the World API adapter.
+- Add authenticated unlock and unlock-revocation operations.

--- a/modules/browser-game-world-api/README.md
+++ b/modules/browser-game-world-api/README.md
@@ -1,3 +1,3 @@
 # Browser Game World API
 
-Authenticated world catalog and travel adapter under `/api/v1/browser-game/world`.
+Authenticated world catalog and travel adapter under `/api/v1/browser-game/world`. Gated destinations require a persisted actor unlock; use `POST /{entity}/unlock` and `DELETE /unlocks/{unlock}` for the unlock lifecycle.

--- a/modules/browser-game-world-api/openapi/v1-browser-game-world.yaml
+++ b/modules/browser-game-world-api/openapi/v1-browser-game-world.yaml
@@ -15,7 +15,7 @@ paths:
       security: [{ sanctum: [] }]
       parameters:
         - { name: kind, in: query, schema: { type: string } }
-        - { name: page[size], in: query, schema: { type: integer, minimum: 1, maximum: 100, default: 25 } }
+        - { name: "page[size]", in: query, schema: { type: integer, minimum: 1, maximum: 100, default: 25 } }
       responses:
         '200': { description: Authorized world catalog }
         '401': { $ref: '#/components/responses/Unauthorized' }
@@ -85,6 +85,30 @@ paths:
       security: [{ sanctum: [] }]
       requestBody: { required: true, content: { application/json: { schema: { type: object, required: [destination_id], properties: { origin_id: { type: string, format: uuid }, destination_id: { type: string, format: uuid }, idempotency_key: { type: string }, metadata: { type: object, additionalProperties: true } } } } } }
       responses: { '201': { $ref: '#/components/responses/Resource' }, '401': { $ref: '#/components/responses/Unauthorized' }, '422': { $ref: '#/components/responses/ValidationError' } }
+  /api/v1/browser-game/world/{entity}/unlock:
+    post:
+      operationId: browser.game.world.unlock
+      summary: Grant an actor's world unlock
+      security: [{ sanctum: [] }]
+      parameters:
+        - { name: entity, in: path, required: true, schema: { type: string, format: uuid } }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                idempotency_key: { type: string, maxLength: 128 }
+                metadata: { type: object, additionalProperties: true }
+      responses: { '201': { $ref: '#/components/responses/UnlockResource' }, '401': { $ref: '#/components/responses/Unauthorized' }, '422': { $ref: '#/components/responses/ValidationError' } }
+  /api/v1/browser-game/world/unlocks/{unlock}:
+    delete:
+      operationId: browser.game.world.unlock.revoke
+      summary: Revoke an actor's world unlock
+      security: [{ sanctum: [] }]
+      parameters:
+        - { name: unlock, in: path, required: true, schema: { type: string, format: uuid } }
+      responses: { '200': { $ref: '#/components/responses/UnlockResource' }, '401': { $ref: '#/components/responses/Unauthorized' }, '422': { $ref: '#/components/responses/ValidationError' } }
 components:
   securitySchemes:
     sanctum: { type: http, scheme: bearer, bearerFormat: Sanctum }
@@ -99,6 +123,23 @@ components:
           type: object
           required: [kind, name, slug, status]
           additionalProperties: true
+    BrowserGameWorldUnlockResource:
+      type: object
+      required: [id, type, attributes]
+      properties:
+        id: { type: string, format: uuid }
+        type: { type: string, const: browser-game-world-unlock }
+        attributes:
+          type: object
+          required: [actor_id, unlock_key, status]
+          properties:
+            actor_id: { type: string }
+            entity_id: { type: string, format: uuid, nullable: true }
+            unlock_key: { type: string }
+            status: { type: string, enum: [granted, revoked] }
+            metadata: { type: object, additionalProperties: true }
+            granted_at: { type: string, format: date-time }
+            revoked_at: { type: string, format: date-time, nullable: true }
     Problem:
       type: object
       required: [title, status]
@@ -116,6 +157,15 @@ components:
             required: [data]
             properties:
               data: { $ref: '#/components/schemas/BrowserGameWorldResource' }
+    UnlockResource:
+      description: An actor world unlock.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [data]
+            properties:
+              data: { $ref: '#/components/schemas/BrowserGameWorldUnlockResource' }
     ValidationError:
       description: Request validation failed.
       content: { application/problem+json: { schema: { $ref: '#/components/schemas/Problem' } } }

--- a/modules/browser-game-world-api/routes/api.php
+++ b/modules/browser-game-world-api/routes/api.php
@@ -9,6 +9,8 @@ Route::prefix('api/v1/browser-game/world')->middleware(['api', 'auth:sanctum', '
     Route::get('/', [WorldController::class, 'index'])->name('browser-game.world.index');
     Route::post('/', [WorldController::class, 'store'])->name('browser-game.world.store');
     Route::post('/travel', [WorldController::class, 'travel'])->name('browser-game.world.travel');
+    Route::post('/{entity}/unlock', [WorldController::class, 'unlock'])->name('browser-game.world.unlock');
+    Route::delete('/unlocks/{unlock}', [WorldController::class, 'revokeUnlock'])->name('browser-game.world.unlock.revoke');
     Route::patch('/{entity}', [WorldController::class, 'update'])->name('browser-game.world.update');
     Route::get('/{entity}', [WorldController::class, 'show'])->name('browser-game.world.show');
 });

--- a/modules/browser-game-world-api/src/Http/Controllers/WorldController.php
+++ b/modules/browser-game-world-api/src/Http/Controllers/WorldController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Liberu\BrowserGame\World\Models\WorldEntity;
+use Liberu\BrowserGame\World\Models\WorldUnlock;
 use Liberu\BrowserGame\World\Queries\WorldQuery;
 use Liberu\BrowserGame\World\Support\WorldManager;
 
@@ -38,11 +39,31 @@ final class WorldController extends Controller
         $user = $request->user();
         $team = is_object($user) && method_exists($user, 'currentTeam') ? $user->currentTeam : null;
         $query = app(WorldQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey());
-        $destination = $query->whereKey($v['destination_id'])->firstOrFail();
-        $origin = isset($v['origin_id']) ? $query->whereKey($v['origin_id'])->firstOrFail() : null;
+        $destination = (clone $query)->whereKey($v['destination_id'])->firstOrFail();
+        $origin = isset($v['origin_id']) ? (clone $query)->whereKey($v['origin_id'])->firstOrFail() : null;
         $travel = app(WorldManager::class)->travel((string) $request->user()->getAuthIdentifier(), $team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey(), $origin, $destination, $v['idempotency_key'] ?? null, $v['metadata'] ?? []);
 
         return response()->json(['data' => ['id' => (string) $travel->getKey(), 'type' => 'browser-game-world-travel', 'attributes' => ['actor_id' => $travel->actor_id, 'origin_id' => $travel->origin_id, 'destination_id' => $travel->destination_id, 'metadata' => $travel->metadata]]], 201);
+    }
+
+    public function unlock(Request $request, WorldEntity $entity): JsonResponse
+    {
+        $user = $request->user();
+        $team = is_object($user) && method_exists($user, 'currentTeam') ? $user->currentTeam : null;
+        $scope = app(WorldQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey())->whereKey($entity->getKey())->firstOrFail();
+        $v = $request->validate(['idempotency_key' => ['nullable', 'string', 'max:128'], 'metadata' => ['array']]);
+        $unlock = app(WorldManager::class)->grantUnlock((string) $request->user()->getAuthIdentifier(), $scope, $team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey(), $v['idempotency_key'] ?? null, $v['metadata'] ?? []);
+
+        return response()->json(['data' => $this->unlockResource($unlock)], 201);
+    }
+
+    public function revokeUnlock(Request $request, WorldUnlock $unlock): JsonResponse
+    {
+        $user = $request->user();
+        $team = is_object($user) && method_exists($user, 'currentTeam') ? $user->currentTeam : null;
+        $updated = app(WorldManager::class)->revokeUnlock((string) $request->user()->getAuthIdentifier(), $unlock, $team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey());
+
+        return response()->json(['data' => $this->unlockResource($updated)]);
     }
 
     public function show(Request $request, WorldEntity $entity): JsonResponse
@@ -68,5 +89,10 @@ final class WorldController extends Controller
     private function resource(WorldEntity $entity): array
     {
         return ['id' => (string) $entity->getKey(), 'type' => 'browser-game-world', 'attributes' => ['kind' => $entity->kind, 'name' => $entity->name, 'slug' => $entity->slug, 'status' => $entity->status, 'attributes' => $entity->attributes, 'coordinates' => $entity->coordinates, 'unlock_key' => $entity->unlock_key, 'created_at' => $entity->created_at?->toISOString(), 'updated_at' => $entity->updated_at?->toISOString()]];
+    }
+
+    private function unlockResource(WorldUnlock $unlock): array
+    {
+        return ['id' => (string) $unlock->getKey(), 'type' => 'browser-game-world-unlock', 'attributes' => ['actor_id' => $unlock->actor_id, 'entity_id' => $unlock->entity_id, 'unlock_key' => $unlock->unlock_key, 'status' => $unlock->status, 'metadata' => $unlock->metadata, 'granted_at' => $unlock->granted_at?->toISOString(), 'revoked_at' => $unlock->revoked_at?->toISOString()]];
     }
 }

--- a/modules/browser-game-world-filament/CHANGELOG.md
+++ b/modules/browser-game-world-filament/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## 1.0.0 - Unreleased
 
 - Add the World Filament adapter.
+- Added a scoped, confirmed grant-unlock action for gated world entities.

--- a/modules/browser-game-world-filament/src/Resources/WorldEntityResource.php
+++ b/modules/browser-game-world-filament/src/Resources/WorldEntityResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\BrowserGame\WorldFilament\Resources;
 
+use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\Select;
@@ -14,6 +15,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Liberu\BrowserGame\World\Models\WorldEntity;
+use Liberu\BrowserGame\World\Support\WorldManager;
 
 final class WorldEntityResource extends Resource
 {
@@ -32,7 +34,16 @@ final class WorldEntityResource extends Resource
 
     public static function table(Table $table): Table
     {
-        return $table->columns([TextColumn::make('name')->searchable(), TextColumn::make('kind')->badge(), TextColumn::make('status')->badge()])->actions([EditAction::make(), DeleteAction::make()]);
+        return $table->columns([TextColumn::make('name')->searchable(), TextColumn::make('kind')->badge(), TextColumn::make('status')->badge()])->actions([
+            EditAction::make(),
+            Action::make('grantUnlock')->label('Grant unlock')->requiresConfirmation()->visible(fn (WorldEntity $record): bool => filled($record->unlock_key))->action(function (WorldEntity $record): void {
+                $user = auth()->user();
+                $team = is_object($user) && method_exists($user, 'currentTeam') ? $user->currentTeam : null;
+                abort_unless($team !== null, 403);
+                app(WorldManager::class)->grantUnlock((string) auth()->id(), $record, $team->getAttribute('tenant_id'), (string) $team->getKey(), 'filament:unlock:'.auth()->id().':'.$record->getKey());
+            }),
+            DeleteAction::make(),
+        ]);
     }
 
     public static function getEloquentQuery(): Builder

--- a/modules/browser-game-world-livewire/CHANGELOG.md
+++ b/modules/browser-game-world-livewire/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - Add the World Livewire adapter.
 - Added rendered origin/destination travel controls.
+- Added unlock controls backed by the domain unlock lifecycle.

--- a/modules/browser-game-world-livewire/resources/views/world-catalog.blade.php
+++ b/modules/browser-game-world-livewire/resources/views/world-catalog.blade.php
@@ -7,7 +7,7 @@
         <button type="submit">Travel</button>
     </form>
     @forelse ($entities as $entity)
-        <article><h3>{{ $entity->name }}</h3><p>{{ $entity->kind }}</p></article>
+        <article><h3>{{ $entity->name }}</h3><p>{{ $entity->kind }}</p>@if($entity->unlock_key)<button type="button" wire:click="unlock('{{ $entity->getKey() }}')">Unlock</button>@endif</article>
     @empty
         <p role="status">No world content is available.</p>
     @endforelse

--- a/modules/browser-game-world-livewire/src/Livewire/WorldCatalog.php
+++ b/modules/browser-game-world-livewire/src/Livewire/WorldCatalog.php
@@ -16,6 +16,16 @@ final class WorldCatalog extends Component
 
     public ?string $message = null;
 
+    public function unlock(string $entityId): void
+    {
+        abort_unless(auth()->check(), 403);
+        $user = auth()->user();
+        $team = is_object($user) && method_exists($user, 'currentTeam') ? $user->currentTeam : null;
+        $entity = app(WorldQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey())->whereKey($entityId)->firstOrFail();
+        app(WorldManager::class)->grantUnlock((string) auth()->id(), $entity, $team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey(), 'livewire:unlock:'.auth()->id().':'.$entityId);
+        $this->message = 'Unlock granted.';
+    }
+
     public function travel(string $originId, string $destinationId): void
     {
         abort_unless(auth()->check(), 403);

--- a/modules/browser-game-world/CHANGELOG.md
+++ b/modules/browser-game-world/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Add the Browser Game World catalog and travel boundary.
 - Added typed region, location, map, encounter, NPC, resource, weather, and unlock definition actions.
 - Rejected travel idempotency-key reuse for a different route or context.
+- Persist actor unlock grants and revocations, enforce them during travel, and expose the lifecycle through the API, Livewire, and Filament surfaces.

--- a/modules/browser-game-world/README.md
+++ b/modules/browser-game-world/README.md
@@ -2,4 +2,4 @@
 
 The World module owns the typed world catalog and travel provenance. `WorldManager` validates catalog kinds, scope, unlock requirements, and travel targets; `WorldQuery` exposes authorized read models. Catalog payloads are data-only JSON and never executable input.
 
-Supported kinds are `region`, `location`, `map`, `encounter`, `npc`, `resource`, `weather`, and `unlock`. Travel writes an immutable record with actor, origin, destination, and idempotency key.
+Supported kinds are `region`, `location`, `map`, `encounter`, `npc`, `resource`, `weather`, and `unlock`. Travel writes an immutable record with actor, origin, destination, and idempotency key. Actor unlocks are persisted in the module-owned unlock table; travel never trusts a client-supplied `unlocked` flag and requires a granted unlock for destinations with an `unlock_key`.

--- a/modules/browser-game-world/database/migrations/2026_08_25_000300_create_browser_game_world_unlocks_table.php
+++ b/modules/browser-game-world/database/migrations/2026_08_25_000300_create_browser_game_world_unlocks_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('browser_game_world_unlocks', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->uuid('tenant_id')->nullable()->index();
+            $table->uuid('team_id')->nullable()->index();
+            $table->uuid('actor_id')->index();
+            $table->uuid('entity_id')->nullable()->index();
+            $table->string('unlock_key');
+            $table->string('status', 24)->default('granted')->index();
+            $table->json('metadata')->nullable();
+            $table->string('idempotency_key')->nullable();
+            $table->timestampTz('granted_at');
+            $table->timestampTz('revoked_at')->nullable();
+            $table->timestamps();
+            $table->unique(['actor_id', 'unlock_key', 'team_id', 'status'], 'browser_game_world_unlocks_actor_key_scope_status');
+            $table->unique(['actor_id', 'idempotency_key'], 'browser_game_world_unlocks_actor_idempotency');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('browser_game_world_unlocks');
+    }
+};

--- a/modules/browser-game-world/src/Events/WorldUnlockGranted.php
+++ b/modules/browser-game-world/src/Events/WorldUnlockGranted.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\BrowserGame\World\Events;
+
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+final readonly class WorldUnlockGranted implements ShouldDispatchAfterCommit
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public string $unlockId, public string $actorId, public string $unlockKey) {}
+}

--- a/modules/browser-game-world/src/Events/WorldUnlockRevoked.php
+++ b/modules/browser-game-world/src/Events/WorldUnlockRevoked.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\BrowserGame\World\Events;
+
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+final readonly class WorldUnlockRevoked implements ShouldDispatchAfterCommit
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public string $unlockId, public string $actorId, public string $unlockKey) {}
+}

--- a/modules/browser-game-world/src/Models/WorldUnlock.php
+++ b/modules/browser-game-world/src/Models/WorldUnlock.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\BrowserGame\World\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+
+final class WorldUnlock extends Model
+{
+    use HasUuids;
+
+    protected $table = 'browser_game_world_unlocks';
+
+    protected $fillable = [
+        'tenant_id', 'team_id', 'actor_id', 'entity_id', 'unlock_key', 'status',
+        'metadata', 'idempotency_key', 'granted_at', 'revoked_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'metadata' => 'array',
+            'granted_at' => 'datetime',
+            'revoked_at' => 'datetime',
+        ];
+    }
+}

--- a/modules/browser-game-world/src/Support/WorldManager.php
+++ b/modules/browser-game-world/src/Support/WorldManager.php
@@ -10,8 +10,11 @@ use Illuminate\Validation\ValidationException;
 use Liberu\BrowserGame\World\Events\WorldEntityDefined;
 use Liberu\BrowserGame\World\Events\WorldEntityUpdated;
 use Liberu\BrowserGame\World\Events\WorldTravelled;
+use Liberu\BrowserGame\World\Events\WorldUnlockGranted;
+use Liberu\BrowserGame\World\Events\WorldUnlockRevoked;
 use Liberu\BrowserGame\World\Models\WorldEntity;
 use Liberu\BrowserGame\World\Models\WorldTravel;
+use Liberu\BrowserGame\World\Models\WorldUnlock;
 
 final class WorldManager
 {
@@ -83,7 +86,7 @@ final class WorldManager
         if ($origin !== null) {
             $this->assertScope($origin, $tenantId, $teamId);
         }
-        if ($destination->getAttribute('status') !== 'active' || ($destination->getAttribute('unlock_key') !== null && ! (bool) ($metadata['unlocked'] ?? false))) {
+        if ($destination->getAttribute('status') !== 'active' || ($destination->getAttribute('unlock_key') !== null && ! $this->hasUnlock($actorId, (string) $destination->getAttribute('unlock_key'), $tenantId, $teamId))) {
             throw ValidationException::withMessages(['destination' => 'The destination is not available.']);
         }
         if ($origin?->getKey() === $destination->getKey() || ($origin !== null && $origin->world_id !== $destination->world_id)) {
@@ -105,6 +108,74 @@ final class WorldManager
         }
 
         return $travel;
+    }
+
+    public function grantUnlock(string $actorId, WorldEntity|string $entity, ?string $tenantId = null, ?string $teamId = null, ?string $idempotencyKey = null, array $metadata = []): WorldUnlock
+    {
+        if (trim($actorId) === '') {
+            throw ValidationException::withMessages(['actor' => 'An actor is required.']);
+        }
+
+        $worldEntity = $entity instanceof WorldEntity ? $entity : WorldEntity::query()->whereKey($entity)->firstOrFail();
+        $this->assertScope($worldEntity, $tenantId, $teamId);
+        $unlockKey = trim((string) $worldEntity->getAttribute('unlock_key'));
+        if ($unlockKey === '') {
+            throw ValidationException::withMessages(['entity' => 'The world entity does not define an unlock key.']);
+        }
+
+        $unlock = DB::transaction(function () use ($actorId, $worldEntity, $tenantId, $teamId, $idempotencyKey, $metadata, $unlockKey): WorldUnlock {
+            if ($idempotencyKey !== null && ($existing = WorldUnlock::query()->where('actor_id', $actorId)->where('idempotency_key', $idempotencyKey)->lockForUpdate()->first())) {
+                if ($existing->unlock_key !== $unlockKey || $existing->tenant_id !== $tenantId || (string) $existing->team_id !== (string) $teamId) {
+                    throw ValidationException::withMessages(['idempotency_key' => 'The idempotency key belongs to another unlock operation.']);
+                }
+
+                return $existing;
+            }
+
+            $existing = WorldUnlock::query()->where('actor_id', $actorId)->where('unlock_key', $unlockKey)->where('status', 'granted')->where(fn ($query) => $query->whereNull('tenant_id')->orWhere('tenant_id', $tenantId))->where(fn ($query) => $query->whereNull('team_id')->orWhere('team_id', $teamId))->lockForUpdate()->first();
+            if ($existing !== null) {
+                if ($idempotencyKey !== null && $existing->idempotency_key === null) {
+                    $existing->update(['idempotency_key' => $idempotencyKey]);
+                }
+
+                return $existing->refresh();
+            }
+
+            return WorldUnlock::query()->create([
+                'id' => (string) Str::uuid(), 'tenant_id' => $tenantId, 'team_id' => $teamId,
+                'actor_id' => $actorId, 'entity_id' => $worldEntity->getKey(), 'unlock_key' => $unlockKey,
+                'status' => 'granted', 'metadata' => $metadata, 'idempotency_key' => $idempotencyKey,
+                'granted_at' => now(),
+            ]);
+        });
+
+        if ($unlock->wasRecentlyCreated) {
+            WorldUnlockGranted::dispatch((string) $unlock->getKey(), $actorId, $unlockKey);
+        }
+
+        return $unlock;
+    }
+
+    public function revokeUnlock(string $actorId, WorldUnlock|int|string $unlock, ?string $tenantId = null, ?string $teamId = null): WorldUnlock
+    {
+        $record = $unlock instanceof WorldUnlock ? $unlock : WorldUnlock::query()->whereKey($unlock)->firstOrFail();
+        if ($record->actor_id !== $actorId || $record->tenant_id !== $tenantId || (string) $record->team_id !== (string) $teamId) {
+            throw ValidationException::withMessages(['unlock' => 'The unlock is not available in the current context.']);
+        }
+        if ($record->status !== 'granted') {
+            return $record;
+        }
+
+        $record->update(['status' => 'revoked', 'revoked_at' => now()]);
+        $record = $record->refresh();
+        WorldUnlockRevoked::dispatch((string) $record->getKey(), $actorId, $record->unlock_key);
+
+        return $record;
+    }
+
+    public function hasUnlock(string $actorId, string $unlockKey, ?string $tenantId = null, ?string $teamId = null): bool
+    {
+        return WorldUnlock::query()->where('actor_id', $actorId)->where('unlock_key', $unlockKey)->where('status', 'granted')->where(fn ($query) => $query->whereNull('tenant_id')->orWhere('tenant_id', $tenantId))->where(fn ($query) => $query->whereNull('team_id')->orWhere('team_id', $teamId))->exists();
     }
 
     public function update(WorldEntity $entity, ?string $tenantId, ?string $teamId, string $name, string $slug, string $status, array $attributes = [], ?array $coordinates = null, ?string $unlockKey = null): WorldEntity

--- a/tests/Feature/BrowserGameAccountsTest.php
+++ b/tests/Feature/BrowserGameAccountsTest.php
@@ -41,3 +41,16 @@ it('anonymizes an account and revokes its sessions on completed deletion', funct
         ->and($account->fresh()->email)->toBeNull()
         ->and($manager->resolveSession($session['token']))->toBeNull();
 });
+
+it('consumes recovery tokens once and rejects expired tokens', function (): void {
+    $manager = app(AccountsManager::class);
+    $account = $manager->define('Recovery Player', ['email' => 'recovery@example.test']);
+    $issued = $manager->issueRecovery($account);
+
+    expect($manager->consumeRecovery($issued['token'])?->getKey())->toBe($account->getKey())
+        ->and($manager->consumeRecovery($issued['token']))->toBeNull();
+
+    $expired = $manager->issueRecovery($account);
+    $expired['recovery']->update(['expires_at' => now()->subMinute()]);
+    expect($manager->consumeRecovery($expired['token']))->toBeNull();
+});

--- a/tests/Feature/BrowserGameQuestsTest.php
+++ b/tests/Feature/BrowserGameQuestsTest.php
@@ -32,13 +32,32 @@ it('accepts quests, validates objectives, and records reward completion evidence
 
 it('enforces prerequisites and permits a repeatable quest to be completed again', function (): void {
     $manager = app(QuestsManager::class);
+    $prior = $manager->define('Prior Quest', 'prior-quest', ['done' => 1]);
     $quest = $manager->define('Repeat Hunt', 'repeat-hunt', ['wins' => 1], [], true);
     $quest->update(['prerequisites' => ['prior-quest']]);
 
     expect(fn (): mixed => $manager->accept($quest, 'player-2'))->toThrow(ValidationException::class);
-    $manager->accept($quest, 'player-2', ['completed_quests' => ['prior-quest']]);
+    $manager->accept($prior, 'player-2');
+    $manager->progress($prior, 'player-2', ['done' => 1], 'completed', 'prior-complete');
+    $manager->accept($quest, 'player-2');
     $first = $manager->progress($quest, 'player-2', ['wins' => 1], 'completed', 'complete-a');
     $second = $manager->progress($quest, 'player-2', ['wins' => 1], 'completed', 'complete-b');
 
     expect($first->completion_count)->toBe(1)->and($second->completion_count)->toBe(2);
+});
+
+it('does not trust client supplied prerequisite completion and keeps completion retries idempotent', function (): void {
+    $manager = app(QuestsManager::class);
+    $quest = $manager->define('Protected Hunt', 'protected-hunt', ['wins' => 1], [], true);
+    $quest->update(['prerequisites' => ['missing-quest']]);
+
+    expect(fn (): mixed => $manager->accept($quest, 'player-3', ['completed_quests' => ['missing-quest']]))
+        ->toThrow(ValidationException::class);
+
+    $quest->update(['prerequisites' => []]);
+    $manager->accept($quest, 'player-3');
+    $first = $manager->progress($quest, 'player-3', ['wins' => 1], 'completed', 'same-completion');
+    $retry = $manager->complete($quest, 'player-3', 'same-completion');
+
+    expect($retry->getKey())->toBe($first->getKey())->and($retry->completion_count)->toBe(1);
 });

--- a/tests/Feature/BrowserGameWorldLifecycleTest.php
+++ b/tests/Feature/BrowserGameWorldLifecycleTest.php
@@ -27,6 +27,24 @@ it('keeps travel scoped, same-world, and idempotent', function (): void {
         ->toThrow(ValidationException::class);
 });
 
+it('requires a persisted actor unlock for gated travel', function (): void {
+    $manager = app(WorldManager::class);
+    $origin = $manager->define('tenant-1', 'team-1', 'location', 'Origin', 'origin', worldId: 'world-1');
+    $destination = $manager->define('tenant-1', 'team-1', 'location', 'Locked', 'locked', worldId: 'world-1', unlockKey: 'world.locked');
+
+    expect(fn (): mixed => $manager->travel('player-1', 'tenant-1', 'team-1', $origin, $destination, 'locked-1', ['unlocked' => true]))
+        ->toThrow(ValidationException::class);
+
+    $unlock = $manager->grantUnlock('player-1', $destination, 'tenant-1', 'team-1', 'unlock-1');
+    expect($unlock->unlock_key)->toBe('world.locked');
+    expect($manager->travel('player-1', 'tenant-1', 'team-1', $origin, $destination, 'locked-1')->destination_id)
+        ->toBe($destination->getKey());
+
+    $manager->revokeUnlock('player-1', $unlock, 'tenant-1', 'team-1');
+    expect(fn (): mixed => $manager->travel('player-1', 'tenant-1', 'team-1', $origin, $destination, 'locked-2'))
+        ->toThrow(ValidationException::class);
+});
+
 it('defines every supported world catalog kind through typed actions', function (): void {
     $manager = app(WorldManager::class);
     $methods = ['defineRegion', 'defineLocation', 'defineMap', 'defineEncounter', 'defineNpc', 'defineResource', 'defineWeather', 'defineUnlock'];

--- a/tests/Feature/GameApiAuthorizationTest.php
+++ b/tests/Feature/GameApiAuthorizationTest.php
@@ -26,6 +26,9 @@ use Liberu\BrowserGame\EconomyApi\EconomyApiServiceProvider;
 use Liberu\BrowserGame\Quests\Models\Quest;
 use Liberu\BrowserGame\Quests\QuestsServiceProvider;
 use Liberu\BrowserGame\QuestsApi\QuestsApiServiceProvider;
+use Liberu\BrowserGame\World\Support\WorldManager;
+use Liberu\BrowserGame\World\WorldServiceProvider;
+use Liberu\BrowserGame\WorldApi\WorldApiServiceProvider;
 use Tests\TestCase;
 
 class GameApiAuthorizationTest extends TestCase
@@ -210,5 +213,28 @@ class GameApiAuthorizationTest extends TestCase
 
         $this->postJson('/api/v1/browser-game/commerce/checkout', ['lines' => [['product_id' => $hidden->getKey(), 'quantity' => 1]]])
             ->assertNotFound();
+    }
+
+    public function test_browser_game_world_unlocks_are_required_for_gated_travel(): void
+    {
+        $this->app->register(WorldServiceProvider::class);
+        $this->app->register(WorldApiServiceProvider::class);
+        $this->artisan('migrate');
+
+        $user = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $user->id]);
+        $user->forceFill(['current_team_id' => $team->getKey()])->save();
+        $manager = app(WorldManager::class);
+        $origin = $manager->define(null, (string) $team->getKey(), 'location', 'Origin', 'origin', worldId: 'world-1');
+        $destination = $manager->define(null, (string) $team->getKey(), 'location', 'Locked', 'locked', worldId: 'world-1', unlockKey: 'world.locked');
+        Sanctum::actingAs($user);
+        $this->postJson('/api/v1/browser-game/world/travel', ['origin_id' => $origin->getKey(), 'destination_id' => $destination->getKey(), 'metadata' => ['unlocked' => true]])
+            ->assertUnprocessable();
+        $unlock = $this->postJson('/api/v1/browser-game/world/'.$destination->getKey().'/unlock', ['idempotency_key' => 'api-unlock-1'])
+            ->assertCreated()
+            ->json('data.id');
+        $this->postJson('/api/v1/browser-game/world/travel', ['origin_id' => $origin->getKey(), 'destination_id' => $destination->getKey(), 'idempotency_key' => 'api-travel-1'])
+            ->assertCreated();
+        $this->deleteJson('/api/v1/browser-game/world/unlocks/'.$unlock)->assertOk()->assertJsonPath('data.attributes.status', 'revoked');
     }
 }


### PR DESCRIPTION
## Summary
- persist scoped actor unlock grants and revocations with post-commit events
- enforce world unlocks authoritatively during travel instead of trusting client metadata
- expose unlock operations through the World API, Livewire, and Filament adapters
- fix mutable query-builder reuse in the World travel API
- make quest prerequisites derive from persisted progress and keep repeatable completion retries idempotent
- make account recovery token consumption atomic

## Validation
- php artisan test — 415 passed, 13 skipped, 1,612 assertions on the World slice baseline; focused World, Accounts, and Quests suites pass after follow-up changes
- touched-file Pint checks passed
- module validation passed
- World OpenAPI YAML parsed successfully