### PR TITLE
Expose Game Core controls in Livewire

### DIFF
--- a/modules/browser-game-game-core-livewire/CHANGELOG.md
+++ b/modules/browser-game-game-core-livewire/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## 1.0.0 - Unreleased
 
 - Add the accessible Game Core world overview component.
+- Add authorized control forms for clocks, rulesets, content versions, feature flags, and maintenance state.

--- a/modules/browser-game-game-core-livewire/README.md
+++ b/modules/browser-game-game-core-livewire/README.md
@@ -1,3 +1,5 @@
 # Browser Game Game Core Livewire
 
 An optional Livewire 4 component that renders an authorized world overview. It keeps browser state minimal and delegates reads to `GameCoreOverview`.
+
+The overview also exposes authorized forms for updating clocks, publishing rulesets and content versions, managing feature flags, and changing maintenance state.

--- a/modules/browser-game-game-core-livewire/resources/views/world-overview.blade.php
+++ b/modules/browser-game-game-core-livewire/resources/views/world-overview.blade.php
@@ -38,6 +38,38 @@
     @if ($overview['maintenance']?->status === 'active')
         <p role="status">{{ $overview['maintenance']->message ?: 'Maintenance is active.' }}</p>
     @endif
-    <button type="button" wire:click="setMaintenance('active', 'Maintenance enabled')" wire:loading.attr="disabled">Enable maintenance</button>
-    <button type="button" wire:click="setMaintenance('resolved')" wire:loading.attr="disabled">Resolve maintenance</button>
+    <form wire:submit="updateClock">
+        <h3>Update game clock</h3>
+        <label>Current time <input type="datetime-local" wire:model="currentAt"></label>
+        <label>Speed <input type="number" min="0" step="0.01" wire:model="clockSpeed"></label>
+        <label><input type="checkbox" wire:model="clockPaused"> Paused</label>
+        <button type="submit" wire:loading.attr="disabled">Save clock</button>
+    </form>
+    <form wire:submit="publishRulesetFromForm">
+        <h3>Publish ruleset</h3>
+        <label>Version <input type="number" min="1" wire:model="rulesetVersion"></label>
+        <label>Rules <textarea wire:model="rulesJson"></textarea></label>
+        <button type="submit" wire:loading.attr="disabled">Publish ruleset</button>
+    </form>
+    <form wire:submit="publishContentFromForm">
+        <h3>Publish content</h3>
+        <label>Version <input type="number" min="1" wire:model="contentVersion"></label>
+        <label>Content hash <input type="text" wire:model="contentHash"></label>
+        <label>Manifest <textarea wire:model="manifestJson"></textarea></label>
+        <button type="submit" wire:loading.attr="disabled">Publish content</button>
+    </form>
+    <form wire:submit="updateFeatureFlagFromForm">
+        <h3>Update feature flag</h3>
+        <label>Key <input type="text" wire:model="featureKey"></label>
+        <label><input type="checkbox" wire:model="featureEnabled"> Enabled</label>
+        <label>Rollout <input type="number" min="0" max="100" wire:model="featureRolloutPercentage"></label>
+        <label>Constraints <textarea wire:model="featureConstraintsJson"></textarea></label>
+        <button type="submit" wire:loading.attr="disabled">Save feature flag</button>
+    </form>
+    <form wire:submit="updateMaintenanceFromForm">
+        <h3>Maintenance</h3>
+        <label>Status <select wire:model="maintenanceStatus"><option value="scheduled">Scheduled</option><option value="active">Active</option><option value="resolved">Resolved</option></select></label>
+        <label>Message <textarea wire:model="maintenanceMessage"></textarea></label>
+        <button type="submit" wire:loading.attr="disabled">Save maintenance</button>
+    </form>
 </section>

--- a/modules/browser-game-game-core-livewire/src/Livewire/WorldOverview.php
+++ b/modules/browser-game-game-core-livewire/src/Livewire/WorldOverview.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Liberu\BrowserGame\GameCoreLivewire\Livewire;
 
+use Illuminate\Validation\ValidationException;
+use JsonException;
 use Liberu\BrowserGame\GameCore\Models\GameWorld;
 use Liberu\BrowserGame\GameCore\Queries\GameCoreOverview as OverviewQuery;
 use Liberu\BrowserGame\GameCore\Support\ArrayGameCoreContext;
@@ -16,9 +18,48 @@ final class WorldOverview extends Component
 
     public ?string $message = null;
 
+    public string $currentAt = '';
+
+    public string $clockSpeed = '1';
+
+    public bool $clockPaused = false;
+
+    public int $rulesetVersion = 1;
+
+    public string $rulesJson = '{}';
+
+    public int $contentVersion = 1;
+
+    public string $contentHash = '';
+
+    public string $manifestJson = '{}';
+
+    public string $featureKey = '';
+
+    public bool $featureEnabled = false;
+
+    public int $featureRolloutPercentage = 100;
+
+    public string $featureConstraintsJson = '{}';
+
+    public string $maintenanceStatus = 'active';
+
+    public string $maintenanceMessage = '';
+
     public function mount(string $worldId): void
     {
         $this->worldId = $worldId;
+        $this->currentAt = now()->format('Y-m-d\\TH:i');
+    }
+
+    public function updateClock(): void
+    {
+        $this->validate([
+            'currentAt' => ['required', 'date'],
+            'clockSpeed' => ['required', 'numeric', 'min:0'],
+            'clockPaused' => ['boolean'],
+        ]);
+        $this->setClock($this->currentAt, $this->clockSpeed, $this->clockPaused);
     }
 
     public function setClock(string $currentAt, string $speed = '1', bool $paused = false): void
@@ -35,6 +76,12 @@ final class WorldOverview extends Component
         $this->message = 'Ruleset published.';
     }
 
+    public function publishRulesetFromForm(): void
+    {
+        $this->validate(['rulesetVersion' => ['required', 'integer', 'min:1'], 'rulesJson' => ['required', 'json']]);
+        $this->publishRuleset($this->rulesetVersion, $this->decodePayload($this->rulesJson, 'rulesJson'));
+    }
+
     public function publishContent(int $version, string $contentHash, array $manifest = []): void
     {
         $context = $this->context();
@@ -42,10 +89,31 @@ final class WorldOverview extends Component
         $this->message = 'Content version published.';
     }
 
+    public function publishContentFromForm(): void
+    {
+        $this->validate([
+            'contentVersion' => ['required', 'integer', 'min:1'],
+            'contentHash' => ['required', 'string', 'max:128'],
+            'manifestJson' => ['required', 'json'],
+        ]);
+        $this->publishContent($this->contentVersion, $this->contentHash, $this->decodePayload($this->manifestJson, 'manifestJson'));
+    }
+
     public function setFeatureFlag(string $key, bool $enabled, int $rolloutPercentage = 100, array $constraints = []): void
     {
         app(GameCoreManager::class)->setFeatureFlag($this->context(), $this->world(), $key, $enabled, $rolloutPercentage, $constraints);
         $this->message = 'Feature flag updated.';
+    }
+
+    public function updateFeatureFlagFromForm(): void
+    {
+        $this->validate([
+            'featureKey' => ['required', 'string', 'max:120'],
+            'featureEnabled' => ['boolean'],
+            'featureRolloutPercentage' => ['required', 'integer', 'min:0', 'max:100'],
+            'featureConstraintsJson' => ['required', 'json'],
+        ]);
+        $this->setFeatureFlag($this->featureKey, $this->featureEnabled, $this->featureRolloutPercentage, $this->decodePayload($this->featureConstraintsJson, 'featureConstraintsJson'));
     }
 
     public function featureEnabled(string $key, array $attributes = []): bool
@@ -57,6 +125,15 @@ final class WorldOverview extends Component
     {
         app(GameCoreManager::class)->setMaintenance($this->context(), $this->world(), $status, $message);
         $this->message = 'Maintenance state updated.';
+    }
+
+    public function updateMaintenanceFromForm(): void
+    {
+        $this->validate([
+            'maintenanceStatus' => ['required', 'in:scheduled,active,resolved'],
+            'maintenanceMessage' => ['nullable', 'string', 'max:2000'],
+        ]);
+        $this->setMaintenance($this->maintenanceStatus, $this->maintenanceMessage !== '' ? $this->maintenanceMessage : null);
     }
 
     public function render(): mixed
@@ -89,5 +166,21 @@ final class WorldOverview extends Component
             ->where(fn ($query) => $query->whereNull('tenant_id')->orWhere('tenant_id', $context->tenantId()))
             ->where(fn ($query) => $query->whereNull('team_id')->orWhere('team_id', $context->teamId()))
             ->firstOrFail();
+    }
+
+    /** @return array<string, mixed> */
+    private function decodePayload(string $payload, string $field): array
+    {
+        try {
+            $decoded = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw ValidationException::withMessages([$field => 'The value must contain valid JSON.']);
+        }
+
+        if (! is_array($decoded)) {
+            throw ValidationException::withMessages([$field => 'The JSON value must be an object.']);
+        }
+
+        return $decoded;
     }
 }

--- a/tests/Feature/BrowserGameGameCoreLivewireTest.php
+++ b/tests/Feature/BrowserGameGameCoreLivewireTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\BrowserGame\GameCore\GameCoreServiceProvider;
+use Liberu\BrowserGame\GameCore\Models\GameClock;
+use Liberu\BrowserGame\GameCore\Models\GameContentVersion;
+use Liberu\BrowserGame\GameCore\Models\GameFeatureFlag;
+use Liberu\BrowserGame\GameCore\Models\GameMaintenanceState;
+use Liberu\BrowserGame\GameCore\Models\GameRuleset;
+use Liberu\BrowserGame\GameCore\Support\ArrayGameCoreContext;
+use Liberu\BrowserGame\GameCore\Support\GameCoreManager;
+use Liberu\BrowserGame\GameCoreLivewire\GameCoreLivewireServiceProvider;
+use Liberu\BrowserGame\GameCoreLivewire\Livewire\WorldOverview;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+it('exposes every Game Core control-plane mutation through Livewire', function (): void {
+    $this->app->register(GameCoreServiceProvider::class);
+    $this->app->register(GameCoreLivewireServiceProvider::class);
+    $this->artisan('migrate');
+
+    $user = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $user->id]);
+    $user->forceFill(['current_team_id' => $team->getKey()])->save();
+    $context = new ArrayGameCoreContext((string) $user->getKey(), null, (string) $team->getKey());
+    $world = app(GameCoreManager::class)->createWorld($context, 'World', 'world');
+
+    Livewire::actingAs($user)->test(WorldOverview::class, ['worldId' => $world->getKey()])
+        ->set('currentAt', '2026-08-29T12:00')
+        ->set('clockSpeed', '2')
+        ->call('updateClock')
+        ->set('rulesetVersion', 2)
+        ->set('rulesJson', '{"combat":{"turns":true}}')
+        ->call('publishRulesetFromForm')
+        ->set('contentVersion', 3)
+        ->set('contentHash', 'sha256:content')
+        ->set('manifestJson', '{"quests":3}')
+        ->call('publishContentFromForm')
+        ->set('featureKey', 'seasonal')
+        ->set('featureEnabled', true)
+        ->set('featureRolloutPercentage', 75)
+        ->set('featureConstraintsJson', '{"team_id":"'.$team->getKey().'"}')
+        ->call('updateFeatureFlagFromForm')
+        ->set('maintenanceStatus', 'active')
+        ->set('maintenanceMessage', 'Maintenance enabled')
+        ->call('updateMaintenanceFromForm')
+        ->assertSee('Maintenance state updated.');
+
+    expect(GameClock::query()->where('world_id', $world->getKey())->value('speed'))->toBe('2.000000')
+        ->and(GameRuleset::query()->where('world_id', $world->getKey())->value('version'))->toBe(2)
+        ->and(GameContentVersion::query()->where('world_id', $world->getKey())->value('version'))->toBe(3)
+        ->and(GameFeatureFlag::query()->where('world_id', $world->getKey())->value('rollout_percentage'))->toBe(75)
+        ->and(GameMaintenanceState::query()->where('world_id', $world->getKey())->value('status'))->toBe('active');
+});
+
+it('rejects malformed Livewire JSON payloads', function (): void {
+    $this->app->register(GameCoreServiceProvider::class);
+    $this->app->register(GameCoreLivewireServiceProvider::class);
+    $this->artisan('migrate');
+
+    $user = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $user->id]);
+    $user->forceFill(['current_team_id' => $team->getKey()])->save();
+    $world = app(GameCoreManager::class)->createWorld(new ArrayGameCoreContext((string) $user->getKey(), null, (string) $team->getKey()), 'World', 'world');
+
+    Livewire::actingAs($user)->test(WorldOverview::class, ['worldId' => $world->getKey()])
+        ->set('rulesJson', 'not-json')
+        ->call('publishRulesetFromForm')
+        ->assertHasErrors(['rulesJson']);
+});


### PR DESCRIPTION
Adds Livewire forms for Game Core clock, ruleset, content, feature flag, and maintenance controls; delegates mutations through existing authorization and adds feature coverage. Full suite: 481 passed, 13 skipped.