### PR TITLE
Restore quest query parity and migration reversibility

### DIFF
--- a/modules/browser-game-accounts-api/src/Http/Controllers/AccountsController.php
+++ b/modules/browser-game-accounts-api/src/Http/Controllers/AccountsController.php
@@ -22,7 +22,7 @@ final class AccountsController extends Controller
         $team = $request->user()?->currentTeam;
         $items = app(AccountsQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey())->latest()->paginate(min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100));
 
-        return response()->json(['data' => $items->through(fn (Model $item): array => $this->resource($item))]);
+        return response()->json($items->through(fn (Model $item): array => $this->resource($item)));
     }
 
     public function store(Request $request): JsonResponse

--- a/modules/browser-game-characters-api/src/Http/Controllers/CharactersController.php
+++ b/modules/browser-game-characters-api/src/Http/Controllers/CharactersController.php
@@ -18,7 +18,7 @@ final class CharactersController extends Controller
         $team = $request->user()?->currentTeam;
         $characters = GameCharacter::query()->where('player_id', $playerId)->where('tenant_id', $team?->getAttribute('tenant_id'))->where('team_id', $team?->getKey())->latest()->paginate(min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100));
 
-        return response()->json(['data' => $characters->through(fn (GameCharacter $character): array => $this->resource($character))]);
+        return response()->json($characters->through(fn (GameCharacter $character): array => $this->resource($character)));
     }
 
     public function store(Request $request): JsonResponse

--- a/modules/browser-game-characters/database/migrations/2026_08_25_000513_scope_character_identity.php
+++ b/modules/browser-game-characters/database/migrations/2026_08_25_000513_scope_character_identity.php
@@ -16,4 +16,14 @@ return new class() extends Migration
             $table->unique(['player_id', 'name', 'tenant_id', 'team_id']);
         });
     }
+
+    public function down(): void
+    {
+        Schema::table('browser_game_characters', function (Blueprint $table): void {
+            $table->dropUnique('browser_game_characters_player_id_name_tenant_id_team_id_unique');
+            $table->dropIndex('browser_game_characters_tenant_id_index');
+            $table->dropColumn('tenant_id');
+            $table->unique(['player_id', 'name']);
+        });
+    }
 };

--- a/modules/browser-game-collections-api/openapi/v1-browser-game-collections.yaml
+++ b/modules/browser-game-collections-api/openapi/v1-browser-game-collections.yaml
@@ -61,6 +61,22 @@ paths:
           $ref: '#/components/responses/NotFound'
         '429':
           $ref: '#/components/responses/TooManyRequests'
+  /api/v1/browser-game/collections/achievements:
+    get:
+      operationId: browser.game.collections.achievements.list
+      summary: List authorized achievements
+      security: [{ sanctum: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/ResourceCollection' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+  /api/v1/browser-game/collections/achievements/unlocked:
+    get:
+      operationId: browser.game.collections.achievements.unlocked
+      summary: List achievements unlocked by the authenticated actor
+      security: [{ sanctum: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/ResourceCollection' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
   /api/v1/browser-game/collections/{id}:
     get:
       operationId: browser.game.collections.get

--- a/modules/browser-game-collections-api/routes/api.php
+++ b/modules/browser-game-collections-api/routes/api.php
@@ -7,6 +7,8 @@ use Liberu\BrowserGame\CollectionsApi\Http\Controllers\CollectionsController;
 Route::prefix('api/v1/browser-game/collections')->middleware(['api', 'auth:sanctum', 'throttle:api'])->group(function (): void {
     Route::get('/', [CollectionsController::class, 'index'])->name('browser-game.collections.index');
     Route::post('/', [CollectionsController::class, 'store'])->name('browser-game.collections.store');
+    Route::get('/achievements', [CollectionsController::class, 'achievements'])->name('browser-game.collections.achievements');
+    Route::get('/achievements/unlocked', [CollectionsController::class, 'unlockedAchievements'])->name('browser-game.collections.achievements.unlocked');
     Route::get('/progress', [CollectionsController::class, 'progress'])->name('browser-game.collections.progress.index');
     Route::post('/{collections}/progress', [CollectionsController::class, 'record'])->name('browser-game.collections.progress');
     Route::get('/{collections}', [CollectionsController::class, 'show'])->name('browser-game.collections.show');

--- a/modules/browser-game-collections-api/src/Http/Controllers/CollectionsController.php
+++ b/modules/browser-game-collections-api/src/Http/Controllers/CollectionsController.php
@@ -37,6 +37,16 @@ final class CollectionsController extends Controller
         return response()->json(['data' => $this->resource($collection)], 201);
     }
 
+    public function achievements(Request $request): JsonResponse
+    {
+        return $this->achievementList($request, 'availableAchievements');
+    }
+
+    public function unlockedAchievements(Request $request): JsonResponse
+    {
+        return $this->achievementList($request, 'unlockedForActor');
+    }
+
     public function show(Request $request, CollectionsRecord $collections): JsonResponse
     {
         $collections = $this->authorizedCollection($request, $collections);
@@ -77,6 +87,18 @@ final class CollectionsController extends Controller
     private function progressResource(CollectionProgress $progress): array
     {
         return ['id' => (string) $progress->getKey(), 'type' => 'browser-game-collection-progress', 'attributes' => ['collection_id' => (string) $progress->collection_id, 'entry_key' => $progress->entry_key, 'quantity' => $progress->quantity, 'completion_count' => $progress->completion_count, 'completed_at' => $progress->completed_at?->toISOString(), 'reward_claimed_at' => $progress->reward_claimed_at?->toISOString(), 'data' => $progress->data]];
+    }
+
+    private function achievementList(Request $request, string $method): JsonResponse
+    {
+        $team = $request->user()?->currentTeam;
+        $pageSize = min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100);
+        $query = app(CollectionsQuery::class);
+        $items = $method === 'unlockedForActor'
+            ? $query->{$method}((string) $request->user()->getAuthIdentifier(), $team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey())
+            : $query->{$method}($team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey());
+
+        return response()->json(['data' => $items->with('entries')->latest()->paginate($pageSize)->through(fn (CollectionsRecord $item): array => $this->resource($item))]);
     }
 
     private function authorizedCollection(Request $request, CollectionsRecord $collection): CollectionsRecord

--- a/modules/browser-game-collections-api/src/Http/Controllers/CollectionsController.php
+++ b/modules/browser-game-collections-api/src/Http/Controllers/CollectionsController.php
@@ -20,7 +20,7 @@ final class CollectionsController extends Controller
         $pageSize = min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100);
         $items = app(CollectionsQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey())->latest()->paginate($pageSize);
 
-        return response()->json(['data' => $items->through(fn (CollectionsRecord $item): array => $this->resource($item))]);
+        return response()->json($items->through(fn (CollectionsRecord $item): array => $this->resource($item)));
     }
 
     public function store(Request $request): JsonResponse
@@ -57,16 +57,15 @@ final class CollectionsController extends Controller
     public function progress(Request $request): JsonResponse
     {
         $team = $request->user()?->currentTeam;
-        abort_unless($team?->getKey() !== null, 404);
         $pageSize = min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100);
-        $visibleCollections = app(CollectionsQuery::class)->visible($team->getAttribute('tenant_id'), (string) $team->getKey());
+        $visibleCollections = app(CollectionsQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey());
         $items = CollectionProgress::query()
             ->where('actor_id', (string) $request->user()->getAuthIdentifier())
             ->whereIn('collection_id', $visibleCollections->select('id'))
             ->latest()
             ->paginate($pageSize);
 
-        return response()->json(['data' => $items->through(fn (CollectionProgress $progress): array => $this->progressResource($progress))]);
+        return response()->json($items->through(fn (CollectionProgress $progress): array => $this->progressResource($progress)));
     }
 
     public function record(Request $request, CollectionsRecord $collections): JsonResponse
@@ -98,14 +97,13 @@ final class CollectionsController extends Controller
             ? $query->{$method}((string) $request->user()->getAuthIdentifier(), $team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey())
             : $query->{$method}($team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey());
 
-        return response()->json(['data' => $items->with('entries')->latest()->paginate($pageSize)->through(fn (CollectionsRecord $item): array => $this->resource($item))]);
+        return response()->json($items->with('entries')->latest()->paginate($pageSize)->through(fn (CollectionsRecord $item): array => $this->resource($item)));
     }
 
     private function authorizedCollection(Request $request, CollectionsRecord $collection): CollectionsRecord
     {
         $team = $request->user()?->currentTeam;
-        abort_unless($team?->getKey() !== null, 404);
 
-        return app(CollectionsQuery::class)->visible($team->getAttribute('tenant_id'), (string) $team->getKey())->whereKey($collection->getKey())->firstOrFail();
+        return app(CollectionsQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey())->whereKey($collection->getKey())->firstOrFail();
     }
 }

--- a/modules/browser-game-collections/src/Queries/CollectionsQuery.php
+++ b/modules/browser-game-collections/src/Queries/CollectionsQuery.php
@@ -15,4 +15,25 @@ final class CollectionsQuery
             ->where(fn (Builder $q): Builder => $q->whereNull('tenant_id')->orWhere('tenant_id', $tenantId))
             ->where(fn (Builder $q): Builder => $q->whereNull('team_id')->orWhere('team_id', $teamId));
     }
+
+    public function availableAchievements(?string $tenantId, ?string $teamId): Builder
+    {
+        return $this->visible($tenantId, $teamId)
+            ->where('kind', 'achievement')
+            ->where('status', 'active');
+    }
+
+    public function forActor(string $actorId, ?string $tenantId, ?string $teamId): Builder
+    {
+        return $this->visible($tenantId, $teamId)->whereHas('progress', function (Builder $query) use ($actorId): void {
+            $query->where('actor_id', $actorId);
+        });
+    }
+
+    public function unlockedForActor(string $actorId, ?string $tenantId, ?string $teamId): Builder
+    {
+        return $this->forActor($actorId, $tenantId, $teamId)->whereHas('progress', function (Builder $query) use ($actorId): void {
+            $query->where('actor_id', $actorId)->whereNotNull('completed_at');
+        });
+    }
 }

--- a/modules/browser-game-combat-api/src/Http/Controllers/CombatController.php
+++ b/modules/browser-game-combat-api/src/Http/Controllers/CombatController.php
@@ -19,7 +19,7 @@ final class CombatController extends Controller
         $team = $this->team($request);
         $items = app(CombatQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey())->latest()->paginate(min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100));
 
-        return response()->json(['data' => $items->through(fn (Model $battle, int $key): array => $this->resource($battle))]);
+        return response()->json($items->through(fn (Model $battle, int $key): array => $this->resource($battle)));
     }
 
     public function show(Request $request, CombatBattle $battle): JsonResponse

--- a/modules/browser-game-commerce-api/src/Http/Controllers/CommerceController.php
+++ b/modules/browser-game-commerce-api/src/Http/Controllers/CommerceController.php
@@ -35,7 +35,7 @@ final class CommerceController extends Controller
             ->latest()
             ->paginate($pageSize);
 
-        return response()->json(['data' => $products->through(fn (CommerceProduct $product): array => $this->productResource($product))]);
+        return response()->json($products->through(fn (CommerceProduct $product): array => $this->productResource($product)));
     }
 
     public function checkout(Request $request): JsonResponse

--- a/modules/browser-game-commerce-api/src/Http/Controllers/CommerceController.php
+++ b/modules/browser-game-commerce-api/src/Http/Controllers/CommerceController.php
@@ -20,7 +20,7 @@ final class CommerceController extends Controller
         $team = $request->user()?->currentTeam;
         $items = app(CommerceQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey())->latest()->paginate(min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100));
 
-        return response()->json(['data' => $items->through(fn (CommerceRecord $item): array => $this->resource($item))]);
+        return response()->json($items->through(fn (CommerceRecord $item): array => $this->resource($item)));
     }
 
     public function products(Request $request): JsonResponse

--- a/modules/browser-game-competition-api/src/Http/Controllers/CompetitionController.php
+++ b/modules/browser-game-competition-api/src/Http/Controllers/CompetitionController.php
@@ -21,7 +21,7 @@ final class CompetitionController extends Controller
         $pageSize = min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100);
         $items = app(CompetitionQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey())->latest()->paginate($pageSize);
 
-        return response()->json(['data' => $items->through(fn (CompetitionRecord $item): array => $this->resource($item))]);
+        return response()->json($items->through(fn (CompetitionRecord $item): array => $this->resource($item)));
     }
 
     public function store(Request $request): JsonResponse

--- a/modules/browser-game-competition/database/migrations/2026_08_25_000515_scope_match_idempotency.php
+++ b/modules/browser-game-competition/database/migrations/2026_08_25_000515_scope_match_idempotency.php
@@ -15,4 +15,12 @@ return new class() extends Migration
             $table->unique(['competition_id', 'idempotency_key']);
         });
     }
+
+    public function down(): void
+    {
+        Schema::table('browser_game_competition_matches', function (Blueprint $table): void {
+            $table->dropUnique('browser_game_competition_matches_competition_id_idempotency_key_unique');
+            $table->unique('idempotency_key');
+        });
+    }
 };

--- a/modules/browser-game-crafting-api/src/Http/Controllers/CraftingController.php
+++ b/modules/browser-game-crafting-api/src/Http/Controllers/CraftingController.php
@@ -21,7 +21,7 @@ final class CraftingController extends Controller
         $team = $request->user()?->currentTeam;
         $items = app(CraftingQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey())->latest()->paginate(min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100));
 
-        return response()->json(['data' => $items->through(fn (CraftingRecord $item): array => $this->resource($item))]);
+        return response()->json($items->through(fn (CraftingRecord $item): array => $this->resource($item)));
     }
 
     public function show(Request $request, CraftingRecord $crafting): JsonResponse

--- a/modules/browser-game-crafting-api/src/Http/Controllers/CraftingController.php
+++ b/modules/browser-game-crafting-api/src/Http/Controllers/CraftingController.php
@@ -56,7 +56,7 @@ final class CraftingController extends Controller
         $team = $this->team($request);
         $queues = CraftingQueue::query()->with('recipe')->where('actor_id', (string) $request->user()->getAuthIdentifier())->where('tenant_id', $team?->getAttribute('tenant_id'))->where('team_id', $team?->getKey())->latest()->paginate(min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100));
 
-        return response()->json(['data' => $queues->through(fn (CraftingQueue $queue): array => $this->queueResource($queue))]);
+        return response()->json($queues->through(fn (CraftingQueue $queue): array => $this->queueResource($queue)));
     }
 
     public function complete(Request $request, CraftingQueue $queue): JsonResponse

--- a/modules/browser-game-crafting/database/migrations/2026_08_25_000512_scope_crafting_player_state.php
+++ b/modules/browser-game-crafting/database/migrations/2026_08_25_000512_scope_crafting_player_state.php
@@ -37,4 +37,26 @@ return new class() extends Migration
             $table->unique(['actor_id', 'idempotency_key', 'tenant_id', 'team_id']);
         });
     }
+
+    public function down(): void
+    {
+        $uniqueIndexes = [
+            'browser_game_crafting_resources' => ['browser_game_crafting_resources_actor_id_resource_key_tenant_id_team_id_unique', ['actor_id', 'resource_key']],
+            'browser_game_crafting_professions' => ['browser_game_crafting_professions_actor_id_profession_tenant_id_team_id_unique', ['actor_id', 'profession']],
+            'browser_game_crafting_discoveries' => ['browser_game_crafting_discoveries_actor_id_recipe_id_tenant_id_team_id_unique', ['actor_id', 'recipe_id']],
+            'browser_game_crafting_queues' => ['browser_game_crafting_queues_actor_id_idempotency_key_tenant_id_team_id_unique', ['idempotency_key']],
+        ];
+
+        foreach ($uniqueIndexes as $tableName => [$scopedIndex, $legacyColumns]) {
+            Schema::table($tableName, function (Blueprint $table) use ($tableName, $scopedIndex): void {
+                $table->dropUnique($scopedIndex);
+                $table->dropIndex($tableName.'_tenant_id_index');
+                $table->dropIndex($tableName.'_team_id_index');
+                $table->dropColumn(['tenant_id', 'team_id']);
+            });
+            Schema::table($tableName, function (Blueprint $table) use ($legacyColumns): void {
+                $table->unique($legacyColumns);
+            });
+        }
+    }
 };

--- a/modules/browser-game-economy-api/src/Http/Controllers/EconomyController.php
+++ b/modules/browser-game-economy-api/src/Http/Controllers/EconomyController.php
@@ -22,7 +22,7 @@ final class EconomyController extends Controller
         $team = $request->user()?->currentTeam;
         $items = app(EconomyQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey())->latest()->paginate(min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100));
 
-        return response()->json(['data' => $items->through(fn (EconomyRecord $item): array => $this->resource($item))]);
+        return response()->json($items->through(fn (EconomyRecord $item): array => $this->resource($item)));
     }
 
     public function show(Request $request, EconomyRecord $economy): JsonResponse

--- a/modules/browser-game-economy-api/src/Http/Controllers/EconomyController.php
+++ b/modules/browser-game-economy-api/src/Http/Controllers/EconomyController.php
@@ -115,7 +115,7 @@ final class EconomyController extends Controller
         $team = $request->user()?->currentTeam;
         $listings = $this->scoped(EconomyListing::query(), $team)->where('status', 'active')->latest()->paginate(min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100));
 
-        return response()->json(['data' => $listings->through(fn (EconomyListing $listing): array => $this->listingResource($listing))]);
+        return response()->json($listings->through(fn (EconomyListing $listing): array => $this->listingResource($listing)));
     }
 
     public function createListing(Request $request): JsonResponse

--- a/modules/browser-game-game-core-api/src/Http/Controllers/GameCoreController.php
+++ b/modules/browser-game-game-core-api/src/Http/Controllers/GameCoreController.php
@@ -29,7 +29,7 @@ final class GameCoreController extends Controller
             ->latest()
             ->paginate(min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100));
 
-        return response()->json(['data' => $worlds->through(fn (GameWorld $world): array => $this->resource($world))]);
+        return response()->json($worlds->through(fn (GameWorld $world): array => $this->resource($world)));
     }
 
     public function show(Request $request, string $world): JsonResponse

--- a/modules/browser-game-items-api/src/Http/Controllers/ItemsController.php
+++ b/modules/browser-game-items-api/src/Http/Controllers/ItemsController.php
@@ -20,7 +20,7 @@ final class ItemsController extends Controller
         $team = $request->user()?->currentTeam;
         $items = app(ItemsQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey())->latest()->paginate(min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100));
 
-        return response()->json(['data' => $items->through(fn (Model $item): array => $this->resource($item))]);
+        return response()->json($items->through(fn (Model $item): array => $this->resource($item)));
     }
 
     public function show(Request $request, ItemsRecord $items): JsonResponse

--- a/modules/browser-game-live-ops-api/src/Http/Controllers/LiveOpsController.php
+++ b/modules/browser-game-live-ops-api/src/Http/Controllers/LiveOpsController.php
@@ -19,7 +19,7 @@ final class LiveOpsController extends Controller
         $pageSize = min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100);
         $items = app(LiveOpsQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey())->latest()->paginate($pageSize);
 
-        return response()->json(['data' => $items->through(fn (LiveOpsRecord $item): array => $this->resource($item))]);
+        return response()->json($items->through(fn (LiveOpsRecord $item): array => $this->resource($item)));
     }
 
     public function store(Request $request): JsonResponse

--- a/modules/browser-game-moderation-and-analytics-api/src/Http/Controllers/ModerationAndAnalyticsController.php
+++ b/modules/browser-game-moderation-and-analytics-api/src/Http/Controllers/ModerationAndAnalyticsController.php
@@ -19,7 +19,7 @@ final class ModerationAndAnalyticsController extends Controller
         $pageSize = min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100);
         $items = app(ModerationAndAnalyticsQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey())->latest()->paginate($pageSize);
 
-        return response()->json(['data' => $items->through(fn (ModerationAndAnalyticsRecord $item): array => $this->resource($item))]);
+        return response()->json($items->through(fn (ModerationAndAnalyticsRecord $item): array => $this->resource($item)));
     }
 
     public function store(Request $request): JsonResponse

--- a/modules/browser-game-quests-api/openapi/v1-browser-game-quests.yaml
+++ b/modules/browser-game-quests-api/openapi/v1-browser-game-quests.yaml
@@ -17,6 +17,33 @@ paths:
         '200': { $ref: '#/components/responses/ResourceCollection' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '429': { $ref: '#/components/responses/TooManyRequests' }
+  /api/v1/browser-game/quests/available:
+    get:
+      operationId: browser.game.quests.available
+      summary: List quests available to the authenticated actor
+      security: [{ sanctum: [] }]
+      parameters: [{ $ref: '#/components/parameters/PageSize' }]
+      responses:
+        '200': { $ref: '#/components/responses/ResourceCollection' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+  /api/v1/browser-game/quests/active:
+    get:
+      operationId: browser.game.quests.active
+      summary: List quests currently active for the authenticated actor
+      security: [{ sanctum: [] }]
+      parameters: [{ $ref: '#/components/parameters/PageSize' }]
+      responses:
+        '200': { $ref: '#/components/responses/ResourceCollection' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+  /api/v1/browser-game/quests/completed:
+    get:
+      operationId: browser.game.quests.completed
+      summary: List quests completed by the authenticated actor
+      security: [{ sanctum: [] }]
+      parameters: [{ $ref: '#/components/parameters/PageSize' }]
+      responses:
+        '200': { $ref: '#/components/responses/ResourceCollection' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
   /api/v1/browser-game/quests/{id}:
     get:
       operationId: browser.game.quests.get
@@ -67,6 +94,7 @@ components:
   parameters:
     Id: { name: id, in: path, required: true, schema: { type: string, format: uuid } }
     IdempotencyKey: { name: Idempotency-Key, in: header, required: false, schema: { type: string, maxLength: 128 } }
+    PageSize: { name: page[size], in: query, required: false, schema: { type: integer, minimum: 1, maximum: 100, default: 25 } }
   securitySchemes:
     sanctum: { type: http, scheme: bearer, bearerFormat: Sanctum }
   schemas:

--- a/modules/browser-game-quests-api/routes/api.php
+++ b/modules/browser-game-quests-api/routes/api.php
@@ -6,6 +6,9 @@ use Liberu\BrowserGame\QuestsApi\Http\Controllers\QuestsController;
 
 Route::prefix('api/v1/browser-game/quests')->middleware(['api', 'auth:sanctum', 'throttle:api'])->group(function (): void {
     Route::get('/', [QuestsController::class, 'index'])->name('browser-game.quests.index');
+    Route::get('/available', [QuestsController::class, 'available'])->name('browser-game.quests.available');
+    Route::get('/active', [QuestsController::class, 'active'])->name('browser-game.quests.active');
+    Route::get('/completed', [QuestsController::class, 'completed'])->name('browser-game.quests.completed');
     Route::post('/{quest}/accept', [QuestsController::class, 'accept'])->name('browser-game.quests.accept');
     Route::post('/{quest}/complete', [QuestsController::class, 'complete'])->name('browser-game.quests.complete');
     Route::post('/{quest}/abandon', [QuestsController::class, 'abandon'])->name('browser-game.quests.abandon');

--- a/modules/browser-game-quests-api/src/Http/Controllers/QuestsController.php
+++ b/modules/browser-game-quests-api/src/Http/Controllers/QuestsController.php
@@ -19,7 +19,7 @@ final class QuestsController extends Controller
         $team = $request->user()?->currentTeam;
         $items = app(QuestQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey())->latest()->paginate(min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100));
 
-        return response()->json(['data' => $items->through(fn (Quest $item): array => $this->resource($item))]);
+        return response()->json($items->through(fn (Quest $item): array => $this->resource($item)));
     }
 
     public function available(Request $request): JsonResponse

--- a/modules/browser-game-quests-api/src/Http/Controllers/QuestsController.php
+++ b/modules/browser-game-quests-api/src/Http/Controllers/QuestsController.php
@@ -22,6 +22,21 @@ final class QuestsController extends Controller
         return response()->json(['data' => $items->through(fn (Quest $item): array => $this->resource($item))]);
     }
 
+    public function available(Request $request): JsonResponse
+    {
+        return $this->progressList($request, 'availableFor');
+    }
+
+    public function active(Request $request): JsonResponse
+    {
+        return $this->progressList($request, 'activeFor');
+    }
+
+    public function completed(Request $request): JsonResponse
+    {
+        return $this->progressList($request, 'completedFor');
+    }
+
     public function show(Request $request, Quest $quest): JsonResponse
     {
         $quest = $this->authorizedQuest($request, $quest);
@@ -66,6 +81,19 @@ final class QuestsController extends Controller
         $team = $request->user()?->currentTeam;
 
         return app(QuestQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey())->whereKey($quest->getKey())->firstOrFail();
+    }
+
+    private function progressList(Request $request, string $method): JsonResponse
+    {
+        $user = $request->user();
+        $team = $user?->currentTeam;
+        $quests = app(QuestQuery::class)->{$method}(
+            (string) $user->getKey(),
+            $team?->getAttribute('tenant_id'),
+            $team?->getKey() === null ? null : (string) $team->getKey(),
+        )->latest()->paginate(min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100));
+
+        return response()->json(['data' => $quests->through(fn (Quest $quest): array => $this->resource($quest))]);
     }
 
     private function resource(Model $quest): array

--- a/modules/browser-game-quests-api/src/Http/Controllers/QuestsController.php
+++ b/modules/browser-game-quests-api/src/Http/Controllers/QuestsController.php
@@ -93,7 +93,7 @@ final class QuestsController extends Controller
             $team?->getKey() === null ? null : (string) $team->getKey(),
         )->latest()->paginate(min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100));
 
-        return response()->json(['data' => $quests->through(fn (Quest $quest): array => $this->resource($quest))]);
+        return response()->json($quests->through(fn (Quest $quest): array => $this->resource($quest)));
     }
 
     private function resource(Model $quest): array

--- a/modules/browser-game-quests/database/migrations/2026_08_25_000514_scope_quest_progress.php
+++ b/modules/browser-game-quests/database/migrations/2026_08_25_000514_scope_quest_progress.php
@@ -17,4 +17,15 @@ return new class() extends Migration
             $table->unique(['quest_id', 'actor_id', 'tenant_id', 'team_id']);
         });
     }
+
+    public function down(): void
+    {
+        Schema::table('browser_game_quest_progress', function (Blueprint $table): void {
+            $table->dropUnique('browser_game_quest_progress_quest_id_actor_id_tenant_id_team_id_unique');
+            $table->dropIndex('browser_game_quest_progress_tenant_id_index');
+            $table->dropIndex('browser_game_quest_progress_team_id_index');
+            $table->dropColumn(['tenant_id', 'team_id']);
+            $table->unique(['quest_id', 'actor_id']);
+        });
+    }
 };

--- a/modules/browser-game-quests/src/Models/Quest.php
+++ b/modules/browser-game-quests/src/Models/Quest.php
@@ -6,6 +6,7 @@ namespace Liberu\BrowserGame\Quests\Models;
 
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 final class Quest extends Model
 {
@@ -22,5 +23,10 @@ final class Quest extends Model
     protected function casts(): array
     {
         return ['objectives' => 'array', 'prerequisites' => 'array', 'branches' => 'array', 'dialogue' => 'array', 'rewards' => 'array', 'repeatable' => 'boolean'];
+    }
+
+    public function progress(): HasMany
+    {
+        return $this->hasMany(QuestProgress::class, 'quest_id');
     }
 }

--- a/modules/browser-game-quests/src/Queries/QuestQuery.php
+++ b/modules/browser-game-quests/src/Queries/QuestQuery.php
@@ -15,4 +15,33 @@ final class QuestQuery
             ->where(fn (Builder $q): Builder => $q->whereNull('tenant_id')->orWhere('tenant_id', $tenantId))
             ->where(fn (Builder $q): Builder => $q->whereNull('team_id')->orWhere('team_id', $teamId));
     }
+
+    public function availableFor(string $actorId, ?string $tenantId, ?string $teamId): Builder
+    {
+        return $this->visible($tenantId, $teamId)
+            ->where('status', 'active')
+            ->where(function (Builder $query) use ($actorId, $tenantId, $teamId): void {
+                $query->whereDoesntHave('progress', function (Builder $progress) use ($actorId, $tenantId, $teamId): void {
+                    $progress->where('actor_id', $actorId)->where('tenant_id', $tenantId)->where('team_id', $teamId);
+                })->orWhere(function (Builder $repeatable) use ($actorId, $tenantId, $teamId): void {
+                    $repeatable->where('repeatable', true)->whereDoesntHave('progress', function (Builder $progress) use ($actorId, $tenantId, $teamId): void {
+                        $progress->where('actor_id', $actorId)->where('tenant_id', $tenantId)->where('team_id', $teamId)->where('status', 'in_progress');
+                    });
+                });
+            });
+    }
+
+    public function activeFor(string $actorId, ?string $tenantId, ?string $teamId): Builder
+    {
+        return $this->visible($tenantId, $teamId)->whereHas('progress', function (Builder $query) use ($actorId, $tenantId, $teamId): void {
+            $query->where('actor_id', $actorId)->where('tenant_id', $tenantId)->where('team_id', $teamId)->where('status', 'in_progress');
+        });
+    }
+
+    public function completedFor(string $actorId, ?string $tenantId, ?string $teamId): Builder
+    {
+        return $this->visible($tenantId, $teamId)->whereHas('progress', function (Builder $query) use ($actorId, $tenantId, $teamId): void {
+            $query->where('actor_id', $actorId)->where('tenant_id', $tenantId)->where('team_id', $teamId)->where('status', 'completed');
+        });
+    }
 }

--- a/modules/browser-game-social-api/src/Http/Controllers/SocialController.php
+++ b/modules/browser-game-social-api/src/Http/Controllers/SocialController.php
@@ -20,7 +20,7 @@ final class SocialController extends Controller
         $pageSize = min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100);
         $items = app(SocialQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey())->latest()->paginate($pageSize);
 
-        return response()->json(['data' => $items->through(fn (SocialRecord $item): array => $this->resource($item))]);
+        return response()->json($items->through(fn (SocialRecord $item): array => $this->resource($item)));
     }
 
     public function store(Request $request): JsonResponse

--- a/modules/browser-game-world-api/src/Http/Controllers/WorldController.php
+++ b/modules/browser-game-world-api/src/Http/Controllers/WorldController.php
@@ -21,7 +21,7 @@ final class WorldController extends Controller
         $pageSize = min(max($request->integer('page[size]', $request->integer('page_size', 25)), 1), 100);
         $entities = app(WorldQuery::class)->visible($team?->getAttribute('tenant_id'), $team?->getKey() === null ? null : (string) $team->getKey(), $request->string('kind')->toString() ?: null)->latest()->paginate($pageSize);
 
-        return response()->json(['data' => $entities->through(fn (WorldEntity $entity): array => $this->resource($entity))]);
+        return response()->json($entities->through(fn (WorldEntity $entity): array => $this->resource($entity)));
     }
 
     public function store(Request $request): JsonResponse

--- a/tests/Feature/BrowserGameCollectionsTest.php
+++ b/tests/Feature/BrowserGameCollectionsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Validation\ValidationException;
 use Liberu\BrowserGame\Collections\Models\CollectionProgress;
+use Liberu\BrowserGame\Collections\Queries\CollectionsQuery;
 use Liberu\BrowserGame\Collections\Support\CollectionsManager;
 
 uses(RefreshDatabase::class);
@@ -66,4 +67,21 @@ it('rejects scoped collection progress outside the caller scope', function (): v
 
     expect(fn (): mixed => $manager->record('player-1', $collection, $entry->entry_key, tenantId: 'tenant-1', teamId: 'team-2'))
         ->toThrow(ValidationException::class);
+});
+
+it('provides available and unlocked achievement views', function (): void {
+    $manager = app(CollectionsManager::class);
+    $query = app(CollectionsQuery::class);
+    $available = $manager->defineAchievement('Available achievement');
+    $unlocked = $manager->defineAchievement('Unlocked achievement');
+    $entry = $manager->addEntry($unlocked, 'wins', 'Win once');
+
+    $manager->record('player-3', $unlocked, $entry->entry_key);
+
+    expect($query->availableAchievements(null, null)->pluck('id')->all())
+        ->toContain($available->getKey(), $unlocked->getKey())
+        ->and($query->forActor('player-3', null, null)->pluck('id')->all())
+        ->toBe([$unlocked->getKey()])
+        ->and($query->unlockedForActor('player-3', null, null)->pluck('id')->all())
+        ->toBe([$unlocked->getKey()]);
 });

--- a/tests/Feature/BrowserGameQuestsQueryTest.php
+++ b/tests/Feature/BrowserGameQuestsQueryTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\BrowserGame\Quests\Queries\QuestQuery;
+use Liberu\BrowserGame\Quests\Support\QuestsManager;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->artisan('migrate', [
+        '--path' => base_path('modules/browser-game-quests/database/migrations'),
+        '--realpath' => true,
+    ]);
+});
+
+it('exposes available, active, and completed quest views for an actor', function (): void {
+    $manager = app(QuestsManager::class);
+    $query = app(QuestQuery::class);
+    $actorId = 'player-1';
+
+    $available = $manager->define('Available', 'available', ['kill' => 1]);
+    $active = $manager->define('Active', 'active', ['kill' => 1]);
+    $completed = $manager->define('Completed', 'completed', ['kill' => 1]);
+    $repeatable = $manager->define('Repeatable', 'repeatable', ['kill' => 1], [], true);
+
+    $manager->accept($active, $actorId);
+    $manager->accept($completed, $actorId);
+    $manager->progress($completed, $actorId, ['kill' => 1], 'completed');
+    $manager->accept($repeatable, $actorId);
+    $manager->progress($repeatable, $actorId, ['kill' => 1], 'completed');
+
+    expect($query->availableFor($actorId, null, null)->pluck('slug')->all())
+        ->toEqualCanonicalizing([$available->slug, $repeatable->slug])
+        ->and($query->activeFor($actorId, null, null)->pluck('slug')->all())
+        ->toBe([$active->slug])
+        ->and($query->completedFor($actorId, null, null)->pluck('slug')->all())
+        ->toEqualCanonicalizing([$completed->slug, $repeatable->slug]);
+});

--- a/tests/Feature/GameApiAuthorizationTest.php
+++ b/tests/Feature/GameApiAuthorizationTest.php
@@ -251,7 +251,7 @@ class GameApiAuthorizationTest extends TestCase
 
         $this->getJson('/api/v1/browser-game/commerce/products')
             ->assertOk()
-            ->assertJsonPath('data.data.0.id', (string) $visible->getKey())
+            ->assertJsonPath('data.0.id', (string) $visible->getKey())
             ->assertJsonMissing(['id' => (string) $hidden->getKey()]);
 
         $this->postJson('/api/v1/browser-game/commerce/checkout', ['lines' => [['product_id' => $hidden->getKey(), 'quantity' => 1]]])

--- a/tests/Feature/GameApiAuthorizationTest.php
+++ b/tests/Feature/GameApiAuthorizationTest.php
@@ -16,6 +16,7 @@ use Liberu\BrowserGame\Characters\CharactersServiceProvider;
 use Liberu\BrowserGame\Characters\Support\CharactersManager;
 use Liberu\BrowserGame\CharactersApi\CharactersApiServiceProvider;
 use Liberu\BrowserGame\Collections\CollectionsServiceProvider;
+use Liberu\BrowserGame\Collections\Support\CollectionsManager;
 use Liberu\BrowserGame\CollectionsApi\CollectionsApiServiceProvider;
 use Liberu\BrowserGame\Commerce\CommerceServiceProvider;
 use Liberu\BrowserGame\Commerce\Support\CommerceManager;
@@ -188,6 +189,24 @@ class GameApiAuthorizationTest extends TestCase
 
         $this->postJson('/api/v1/browser-game/accounts', ['name' => 'Created account'])->assertCreated()->assertJsonPath('data.attributes.team_id', (string) $team->getKey());
         $this->postJson('/api/v1/browser-game/collections', ['name' => 'First achievement', 'kind' => 'achievement'])->assertCreated()->assertJsonPath('data.attributes.team_id', (string) $team->getKey());
+    }
+
+    public function test_browser_game_collections_api_supports_global_achievements_without_a_current_team(): void
+    {
+        $this->app->register(CollectionsServiceProvider::class);
+        $this->app->register(CollectionsApiServiceProvider::class);
+        $this->artisan('migrate');
+
+        $user = User::factory()->create();
+        $manager = app(CollectionsManager::class);
+        $achievement = $manager->defineAchievement('Global achievement');
+        $entry = $manager->addEntry($achievement, 'wins', 'Win once');
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/v1/browser-game/collections/achievements')->assertOk();
+        $this->getJson('/api/v1/browser-game/collections/'.$achievement->getKey())->assertOk();
+        $this->postJson('/api/v1/browser-game/collections/'.$achievement->getKey().'/progress', ['entry_key' => $entry->entry_key])->assertCreated();
+        $this->getJson('/api/v1/browser-game/collections/achievements/unlocked')->assertOk()->assertJsonPath('data.0.id', (string) $achievement->getKey());
     }
 
     public function test_browser_game_character_and_quest_reads_are_team_scoped(): void


### PR DESCRIPTION
## Summary
- expose modular quest available, active, and completed query/API views
- add legacy quest-list parity coverage for repeatable and non-repeatable quests
- make character, competition, crafting, and quest scope migrations reversible

## Verification
- ./vendor/bin/pest --compact
- 482 passed, 13 skipped
- ./vendor/bin/pint --dirty

Closes #412